### PR TITLE
chore: corepack up for pnpm that added a sha key

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@10.11.1+sha512.e519b9f7639869dc8d5c3c5dfef73b3f091094b0a006d7317353c72b124e80e1afd429732e28705ad6bfa1ee879c1fce46c128ccebd3192101f43dd67c667912",
   "devDependencies": {
     "@eslint/css": "^0.8.1",
     "@eslint/js": "^9.28.0",


### PR DESCRIPTION
# First Commit of mine :fairy:  :fairy_man:  :fairy_woman: 


When cloning the project, installing pnpm failed for me.

On updating pnpm both on my machine and on the project, it changed and added a sha to the package.json automatically.

Now it works